### PR TITLE
Make it safe to use FDs once more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,13 @@ version = "1.0.0"
 crate-type = ["cdylib"]
 
 [dependencies]
+backoff = "0.4.0"
+libc = "0.2.152"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.12.2", default-features = false, features = ["napi4"] }
 napi-derive = "2.12.2"
 rustix = { version = "0.38.30", features = ["event"] }
 rustix-openpty = "0.1.1"
-libc = "0.2.152"
 
 [build-dependencies]
 napi-build = "2.0.1"


### PR DESCRIPTION
We're currently using nodejs with the `onData` callback. But we know that's slow because it crosses the FFI barrier.

This change now makes it safe to use the file descriptor.

## Test

```shell
lhchavez@luisval:~/ruspty$ cat test.js 
const { Pty } = require('./index');
const fs = require('fs');

const ENV = process.env;
const CWD = '.';

let firstread = true;

const pty = new Pty({
  command: 'sh',
  env: ENV,
  cwd: CWD,
  size: { rows: 24, cols: 80 },
  onExit: (...result) => {
    console.log({ result });
    pty.close();
  },
});

const read = fs.createReadStream('', {
  fd: pty.fd(),
  autoClose: true,
});

read.on('data', (chunk) => {
  console.log(chunk.toString());
  if (firstread) {
    write.write('ls && sleep 2 && exit 0\n');
    firstread = false;
  }
});
read.on('close', () => {
  console.log('read close');
});
read.on('error', (err) => {
  if (err.code && err.code.indexOf('EIO') !== -1) {
    console.log('YAY');
  } else {
    console.log('read error', { err });
  }
});

const write = fs.createWriteStream('', {
  fd: pty.fd(),
  autoClose: true,
});

write.on('close', () => {
  console.log('write close');
});

write.on('error', (err) => {
  if (err.code && err.code.indexOf('EIO') !== -1) {
    console.log('YAY');
  } else {
    console.log('write error', { err });
  }
});

console.log('gonna wait');
setTimeout(() => {
  console.log('done, hopefully');
}, 3000);
lhchavez@luisval:~/ruspty$ node test.js 
gonna wait
sh-5.2$ 
ls && sleep 2 && exit 0

1.0.26.txt  README.md   index.d.ts    package-lock.json          src
1.1.6.txt   build.rs    index.js      package.json               target
1.1.7.txt   bun.lockb   node.txt      replit.nix                 test.js
Cargo.lock  flake.lock  node_modules  ruspty.linux-x64-gnu.node  tests
Cargo.toml  flake.nix   npm           rustfmt.toml

exit

{ result: [ null, 0 ] }
YAY
read close
done, hopefully
```