### PR TITLE
3.1.0 Add functions to get/set the close-on-exec flag

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,16 @@ export interface Size {
   cols: number
   rows: number
 }
+/**
+ * Set the close-on-exec flag on a file descriptor. This is `fcntl(fd, F_SETFD, FD_CLOEXEC)` under
+ * the covers.
+ */
+export function setCloseOnExec(fd: number, closeOnExec: boolean): void
+/**
+ * Get the close-on-exec flag on a file descriptor. This is `fcntl(fd, F_GETFD) & FD_CLOEXEC ==
+ *_CLOEXEC` under the covers.
+ */
+export function getCloseOnExec(fd: number): boolean
 export class Pty {
   /** The pid of the forked process. */
   pid: number

--- a/index.js
+++ b/index.js
@@ -310,6 +310,8 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Pty } = nativeBinding
+const { Pty, setCloseOnExec, getCloseOnExec } = nativeBinding
 
 module.exports.Pty = Pty
+module.exports.setCloseOnExec = setCloseOnExec
+module.exports.getCloseOnExec = getCloseOnExec

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.0.5",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",


### PR DESCRIPTION
pid2 needs to set the close-on-exec flag on a certain file descriptor, but node doesn't have an API to achieve this. The only other node module that provides the `fcntl(2)` binding doesn't play well with esbuild, so we need to recruit the help of our friend here.

This change adds two functions to get/set the close-on-exec flag on a file descriptor.