### PR TITLE
3.1.1 Do not leak file descriptors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export function setCloseOnExec(fd: number, closeOnExec: boolean): void
  *_CLOEXEC` under the covers.
  */
 export function getCloseOnExec(fd: number): boolean
-export class Pty {
+export declare class Pty {
   /** The pid of the forked process. */
   pid: number
   constructor(opts: PtyOptions)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",


### PR DESCRIPTION
The `openpty` function was created on a simpler time, when `O_CLOEXEC` was not even a thing. Leaking file descriptors was _fine_. But we don't live in that world anymore.

This change now marks both ends of the PTY as close-on-exec, so that the file descriptors are not leaked. Importantly, since we rely on both copies (the one in ruspty and the one in the child) being closed to consider the stream done, _if_ we manage to leak the FD to another shell, there will be an unexpected third copy, so the stream will unnecessarily hang for a second (good that we added a failsafe cap on execution time)!