### PR TITLE
3.1.2 Set the PTY fd to be non-blocking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ export interface Size {
   cols: number
   rows: number
 }
+/** Resize the terminal. */
+export function ptyResize(fd: number, size: Size): void
 /**
  * Set the close-on-exec flag on a file descriptor. This is `fcntl(fd, F_SETFD, FD_CLOEXEC)` under
  * the covers.
@@ -27,24 +29,14 @@ export function setCloseOnExec(fd: number, closeOnExec: boolean): void
  *_CLOEXEC` under the covers.
  */
 export function getCloseOnExec(fd: number): boolean
-export declare class Pty {
+export class Pty {
   /** The pid of the forked process. */
   pid: number
   constructor(opts: PtyOptions)
-  /** Resize the terminal. */
-  resize(size: Size): void
   /**
-   * Returns a file descriptor for the PTY controller.
-   * See the docstring of the class for an usage example.
+   * Transfers ownership of the file descriptor for the PTY controller. This can only be called
+   * once (it will error the second time). The caller is responsible for closing the file
+   * descriptor.
    */
-  fd(): c_int
-  /**
-   * Close the PTY file descriptor. This must be called when the readers / writers of the PTY have
-   * been closed, otherwise we will leak file descriptors!
-   *
-   * In an ideal world, this would be automatically called after the wait loop is done, but Node
-   * doesn't like that one bit, since it implies that the file is closed outside of the main
-   * event loop.
-   */
-  close(): void
+  takeFd(): c_int
 }

--- a/index.js
+++ b/index.js
@@ -310,8 +310,9 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { Pty, setCloseOnExec, getCloseOnExec } = nativeBinding
+const { Pty, ptyResize, setCloseOnExec, getCloseOnExec } = nativeBinding
 
 module.exports.Pty = Pty
+module.exports.ptyResize = ptyResize
 module.exports.setCloseOnExec = setCloseOnExec
 module.exports.getCloseOnExec = getCloseOnExec

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",


### PR DESCRIPTION
We have gone back and forth a couple of times, but we _do_ need to set this FD to be non-blocking. Otherwise node will fully consume one I/O thread for each PTY, and node only has four of those.

This change makes the controller fd (the one the parent process reads from / writes to) as non-blocking for node.