### PR TITLE
3.1.3 Add an `interactive` flag to PTY

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ export interface PtyOptions {
   envs?: Record<string, string>
   dir?: string
   size?: Size
+  interactive?: boolean
   onExit: (err: null | Error, exitCode: number) => void
 }
 /** A size struct to pass to resize. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ struct PtyOptions {
   pub envs: Option<HashMap<String, String>>,
   pub dir: Option<String>,
   pub size: Option<Size>,
+  pub interactive: Option<bool>,
   #[napi(ts_type = "(err: null | Error, exitCode: number) => void")]
   pub on_exit: JsFunction,
 }
@@ -128,7 +129,11 @@ impl Pty {
     set_nonblocking(controller_fd.as_raw_fd())?;
 
     // duplicate pty user_fd to be the child's stdin, stdout, and stderr
-    cmd.stdin(Stdio::from(user_fd.try_clone()?));
+    if opts.interactive.unwrap_or(true) {
+      cmd.stdin(Stdio::from(user_fd.try_clone()?));
+    } else {
+      cmd.stdin(Stdio::null());
+    }
     cmd.stderr(Stdio::from(user_fd.try_clone()?));
     cmd.stdout(Stdio::from(user_fd.try_clone()?));
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -121,6 +121,34 @@ describe(
         writeStream.end(EOT);
       }));
 
+    test('can be started in non-interactive fashion', () =>
+      new Promise<void>((done) => {
+        const oldFds = getOpenFds();
+
+        let buffer = '';
+
+        const expectedResult = '\r\n';
+
+        const pty = new Pty({
+          command: '/bin/cat',
+          interactive: false,
+          onExit: (err, exitCode) => {
+            expect(err).toBeNull();
+            expect(exitCode).toBe(0);
+            let result = buffer.toString();
+            expect(result.trim()).toStrictEqual(expectedResult.trim());
+            expect(getOpenFds()).toStrictEqual(oldFds);
+            done();
+          },
+        });
+
+        const readStream = pty.read;
+
+        readStream.on('data', (data) => {
+          buffer += data.toString();
+        });
+      }));
+
     test('can be resized', () =>
       new Promise<void>((done) => {
         const oldFds = getOpenFds();


### PR DESCRIPTION
We want to be able to start processes that don't have a PTY stdin.

https://replit.slack.com/archives/C074CCJSS0M/p1721702561485369

This change adds that flag.