### PR TITLE
3.2.1 dont try to resize if we invalidated the fd

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.0.5",
+  "version": "3.2.1",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.0.5",
+  "version": "3.2.1",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.0.5",
+  "version": "3.2.1",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -254,6 +254,25 @@ describe(
         });
       }));
 
+    test('resize after exit shouldn\'t throw', () => new Promise<void>((done, reject) => {
+      const pty = new Pty({
+        command: '/bin/echo',
+        args: ['hello'],
+        onExit: (err, exitCode) => {
+          try {
+            expect(err).toBeNull();
+            expect(exitCode).toBe(0);
+            expect(() => {
+              pty.resize({ rows: 60, cols: 100 });
+            }).not.toThrow();
+            done();
+          } catch (e) {
+            reject(e)
+          }
+        },
+      });
+    }));
+
     test(
       'ordering is correct',
       () =>


### PR DESCRIPTION
`ioctl TIOCSWINSZ failed: Bad file descriptor (os error 9)` makes me sad

- js owns the fd so its safe to mark the fd as dead after the read stream derived from the pty fd ends
- after the fd is dead, dont try to resize