### PR TITLE
3.2.2 end tty stream cleanly on error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,6 +303,14 @@ impl Pty {
 #[napi]
 #[allow(dead_code)]
 fn pty_resize(fd: i32, size: Size) -> Result<(), napi::Error> {
+  // check the fd is still valid before we try to resize
+  if unsafe { libc::fcntl(fd, libc::F_GETFD) } == -1 {
+    return Err(napi::Error::new(
+      napi::Status::GenericFailure,
+      "fd not valid for resize",
+    ));
+  }
+
   let window_size = Winsize {
     ws_col: size.cols,
     ws_row: size.rows,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,14 +303,6 @@ impl Pty {
 #[napi]
 #[allow(dead_code)]
 fn pty_resize(fd: i32, size: Size) -> Result<(), napi::Error> {
-  // check the fd is still valid before we try to resize
-  if unsafe { libc::fcntl(fd, libc::F_GETFD) } == -1 {
-    return Err(napi::Error::new(
-      napi::Status::GenericFailure,
-      "fd not valid for resize",
-    ));
-  }
-
   let window_size = Winsize {
     ws_col: size.cols,
     ws_row: size.rows,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -254,6 +254,25 @@ describe(
         });
       }));
 
+    test('resize after exit shouldn\'t throw', () => new Promise<void>((done, reject) => {
+      const pty = new Pty({
+        command: '/bin/echo',
+        args: ['hello'],
+        onExit: (err, exitCode) => {
+          try {
+            expect(err).toBeNull();
+            expect(exitCode).toBe(0);
+            expect(() => {
+              pty.resize({ rows: 60, cols: 100 });
+            }).not.toThrow();
+            done();
+          } catch (e) {
+            reject(e)
+          }
+        },
+      });
+    }));
+
     test(
       'ordering is correct',
       () =>

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -120,6 +120,8 @@ export class Pty {
   }
 
   close() {
+    // end instead of destroy so that the user can read the last bits of data
+    // and allow graceful close event to mark the fd as ended
     this.#socket.end();
   }
 
@@ -136,7 +138,7 @@ export class Pty {
         // exited but we don't know about it yet. In that case, we just ignore the error.
         return;
       }
-      
+
       // otherwise, rethrow
       throw e;
     }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -128,7 +128,18 @@ export class Pty {
       return;
     }
 
-    ptyResize(this.#fd, size);
+    try {
+      ptyResize(this.#fd, size);
+    } catch (e: unknown) {
+      if (e instanceof Error && 'code' in e && e.code === 'EBADF') {
+        // EBADF means the file descriptor is invalid. This can happen if the PTY has already
+        // exited but we don't know about it yet. In that case, we just ignore the error.
+        return;
+      }
+      
+      // otherwise, rethrow
+      throw e;
+    }
   }
 
   get pid() {

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -85,12 +85,14 @@ export class Pty {
       }
 
       this.#fdEnded = true;
-      exitResult.then((result) => realExit(result.error, result.code));
+      exitResult.then((result) => {
+        realExit(result.error, result.code)
+      });
       userFacingRead.end();
     };
     this.#socket.on('close', handleClose);
 
-    // PTYs signal their donness with an EIO error. we therefore need to filter them out (as well as
+    // PTYs signal their done-ness with an EIO error. we therefore need to filter them out (as well as
     // cleaning up other spurious errors) so that the user doesn't need to handle them and be in
     // blissful peace.
     const handleError = (err: NodeJS.ErrnoException) => {
@@ -103,11 +105,11 @@ export class Pty {
           return;
         }
         if (code.indexOf('EIO') !== -1) {
-          // EIO only happens when the child dies . It is therefore our only true signal that there
+          // EIO only happens when the child dies. It is therefore our only true signal that there
           // is nothing left to read and we can start tearing things down. If we hadn't received an
           // error so far, we are considered to be in good standing.
           this.#socket.off('error', handleError);
-          this.#socket.destroy();
+          this.#socket.end();
           return;
         }
       }
@@ -118,7 +120,7 @@ export class Pty {
   }
 
   close() {
-    this.#socket.destroy();
+    this.#socket.end();
   }
 
   resize(size: Size) {


### PR DESCRIPTION
- don't `.destroy`, `.end` instead
- add previously failing test `resize after close shouldn\'t throw`
- check the fd is still valid before we try to resize