### PR TITLE
3.3.0 remove a layer of indirection (unnecessary passthrough)

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.2.4",
+      "version": "3.3.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.2.4",
+  "version": "3.3.0",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -76,7 +76,7 @@ describe(
     test('captures an exit code', () =>
       new Promise<void>((done) => {
         const oldFds = getOpenFds();
-        new Pty({
+        const pty = new Pty({
           command: '/bin/sh',
           args: ['-c', 'exit 17'],
           onExit: (err, exitCode) => {
@@ -86,6 +86,9 @@ describe(
             done();
           },
         });
+
+        // set a pty reader so it can flow
+        pty.read.on('data', () => {});
       }));
 
     test('can be written to', () =>
@@ -272,6 +275,8 @@ describe(
           }
         },
       });
+
+      pty.read.on('data', () => {});
     }));
 
     test('resize after close shouldn\'t throw', () => new Promise<void>((done, reject) => {
@@ -286,6 +291,8 @@ describe(
           }
         },
       });
+
+      pty.read.on('data', () => {});
 
       pty.close();
       expect(() => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -332,14 +332,15 @@ describe(
           const payload = `hello`.repeat(4096);
           let buffer = Buffer.from('');
           const pty = new Pty({
-            command: '/bin/sh',
+            command: '/bin/echo',
             args: [
-              '-c',
-              `echo ${payload}`,
+              '-n',
+              payload
             ],
             onExit: (err, exitCode) => {
               expect(err).toBeNull();
               expect(exitCode).toBe(0);
+              // account for the newline
               expect(buffer.toString().length).toBe(payload.length);
               done();
             },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -59,6 +59,7 @@ describe(
           command: '/bin/echo',
           args: [message],
           onExit: (err, exitCode) => {
+            console.log('huhhh')
             expect(err).toBeNull();
             expect(exitCode).toBe(0);
             expect(buffer.trim()).toBe(message);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -59,7 +59,6 @@ describe(
           command: '/bin/echo',
           args: [message],
           onExit: (err, exitCode) => {
-            console.log('huhhh')
             expect(err).toBeNull();
             expect(exitCode).toBe(0);
             expect(buffer.trim()).toBe(message);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -309,16 +309,16 @@ describe(
           let buffer = Buffer.from('');
           const n = 1024;
           const pty = new Pty({
-            command: '/bin/echo',
+            command: '/bin/sh',
             args: [
-              '-n',
-              `${[...Array(n + 1).keys()].join('\n')}`,
+              '-c',
+              'seq 0 1024'
             ],
             onExit: (err, exitCode) => {
               expect(err).toBeNull();
               expect(exitCode).toBe(0);
-              expect(buffer.toString().trim()).toBe(
-                [...Array(n + 1).keys()].join('\r\n'),
+              expect(buffer.toString().trim().split('\n').map(Number)).toStrictEqual(
+                Array.from({ length: n + 1 }, (_, i) => i),
               );
               expect(getOpenFds()).toStrictEqual(oldFds);
               done();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -47,7 +47,7 @@ function getOpenFds(): FdRecord {
 
 describe(
   'PTY',
-  { repeats: 50 },
+  // { repeats: 50 },
   () => {
     test('spawns and exits', () =>
       new Promise<void>((done) => {
@@ -88,7 +88,7 @@ describe(
         });
 
         // set a pty reader so it can flow
-        pty.read.on('data', () => {});
+        pty.read.on('data', () => { });
       }));
 
     test('can be written to', () =>
@@ -276,7 +276,7 @@ describe(
         },
       });
 
-      pty.read.on('data', () => {});
+      pty.read.on('data', () => { });
     }));
 
     test('resize after close shouldn\'t throw', () => new Promise<void>((done, reject) => {
@@ -292,7 +292,7 @@ describe(
         },
       });
 
-      pty.read.on('data', () => {});
+      pty.read.on('data', () => { });
 
       pty.close();
       expect(() => {
@@ -309,10 +309,10 @@ describe(
           let buffer = Buffer.from('');
           const n = 1024;
           const pty = new Pty({
-            command: '/bin/sh',
+            command: '/bin/echo',
             args: [
-              '-c',
-              `for i in $(seq 0 ${n}); do /bin/echo $i; done && exit`,
+              '-n',
+              `${[...Array(n + 1).keys()].join('\n')}`,
             ],
             onExit: (err, exitCode) => {
               expect(err).toBeNull();
@@ -333,7 +333,6 @@ describe(
     );
 
     test('doesnt miss large output from fast commands',
-      { repeats: 50 },
       () =>
         new Promise<void>((done) => {
           const payload = `hello`.repeat(4096);
@@ -362,7 +361,6 @@ describe(
 
     testSkipOnDarwin(
       'does not leak files',
-      { repeats: 4 },
       () =>
         new Promise<void>((done) => {
           const oldFds = getOpenFds();
@@ -408,7 +406,6 @@ describe(
 
     test(
       'can run concurrent shells',
-      { repeats: 4 },
       () =>
         new Promise<void>((done) => {
           const oldFds = getOpenFds();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -47,7 +47,7 @@ function getOpenFds(): FdRecord {
 
 describe(
   'PTY',
-  // { repeats: 50 },
+  { repeats: 50 },
   () => {
     test('spawns and exits', () =>
       new Promise<void>((done) => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -326,7 +326,7 @@ describe(
     );
 
     test('doesnt miss large output from fast commands',
-      { repeats: 10 },
+      { repeats: 50 },
       () =>
         new Promise<void>((done) => {
           const payload = `hello`.repeat(4096);

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -74,12 +74,14 @@ export class Pty {
 
     // catch end events
     const handleClose = () => {
+      console.log('handle close')
       this.#fdEnded = true;
     };
 
 
     let ttyStreamEnded = false;
     const handleEnd = () => {
+      console.log('handle end')
       if (ttyStreamEnded) {
         return;
       }
@@ -109,6 +111,7 @@ export class Pty {
           // EIO only happens when the child dies. It is therefore our only true signal that there
           // is nothing left to read and we can start tearing things down. If we hadn't received an
           // error so far, we are considered to be in good standing.
+          console.log('eio')
           this.read.off('error', handleError);
           handleEnd();
           return;

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -79,11 +79,15 @@ export class Pty {
       }
 
       this.#fdEnded = true;
+    };
+
+    this.read.on('close', handleClose);
+
+    this.read.on('end', () => {
       exitResult.then((result) => {
         realExit(result.error, result.code)
       });
-    };
-    this.read.on('close', handleClose);
+    })
 
     // PTYs signal their done-ness with an EIO error. we therefore need to filter them out (as well as
     // cleaning up other spurious errors) so that the user doesn't need to handle them and be in
@@ -102,6 +106,7 @@ export class Pty {
           // is nothing left to read and we can start tearing things down. If we hadn't received an
           // error so far, we are considered to be in good standing.
           this.read.off('error', handleError);
+          this.write.end();
           return;
         }
       }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -117,7 +117,7 @@ export class Pty {
           // error so far, we are considered to be in good standing.
           console.log('eio')
           this.read.off('error', handleError);
-          markFdClosed();
+          handleEnd();
           return;
         }
       }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -71,12 +71,12 @@ export class Pty {
     this.#fd = this.#pty.takeFd();
 
     this.#socket = new ReadStream(this.#fd);
-    const userFacingRead = new PassThrough();
-    const userFacingWrite = new PassThrough();
-    this.#socket.pipe(userFacingRead);
-    userFacingWrite.pipe(this.#socket);
-    this.read = userFacingRead;
-    this.write = userFacingWrite;
+    // const userFacingRead = new PassThrough();
+    // const userFacingWrite = new PassThrough();
+    // this.#socket.pipe(userFacingRead);
+    // userFacingWrite.pipe(this.#socket);
+    this.read = this.#socket;
+    this.write = this.#socket;
 
     // catch end events
     const handleClose = () => {
@@ -88,7 +88,6 @@ export class Pty {
       exitResult.then((result) => {
         realExit(result.error, result.code)
       });
-      userFacingRead.end();
     };
     this.#socket.on('close', handleClose);
 

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -74,27 +74,18 @@ export class Pty {
     this.write = new WriteStream(this.#fd);
 
     // catch end events
-    const handleClose = () => {
-      console.log('handle close')
-      this.#fdEnded = true;
-    };
-
-
-    let ttyStreamEnded = false;
     const handleEnd = () => {
-      console.log('handle end')
-      if (ttyStreamEnded) {
+      if (this.#fdEnded) {
         return;
       }
 
-      ttyStreamEnded = true;
+      this.#fdEnded = true;
       exitResult.then((result) => {
         console.log('calling real exit')
         realExit(result.error, result.code)
       });
     }
 
-    this.read.on('close', handleClose);
     this.read.on('end', handleEnd);
 
     // PTYs signal their done-ness with an EIO error. we therefore need to filter them out (as well as

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -102,8 +102,6 @@ export class Pty {
           // is nothing left to read and we can start tearing things down. If we hadn't received an
           // error so far, we are considered to be in good standing.
           this.read.off('error', handleError);
-          console.log("EIO")
-          this.write.end();
           return;
         }
       }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -97,7 +97,7 @@ export class Pty {
       realExit(result.error, result.code)
     }
 
-    this.read.on('finish', handleEnd);
+    this.read.on('end', handleEnd);
     this.read.on('close', () => {
       markFdClosed();
     });

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -62,7 +62,6 @@ export class Pty {
       markFdClosed = resolve;
     });
     const mockedExit = (error: NodeJS.ErrnoException | null, code: number) => {
-      console.log('mocked exit')
       markExited({ error, code });
     };
 
@@ -79,7 +78,6 @@ export class Pty {
 
     // catch end events
     const handleEnd = async () => {
-      console.log('handle end')
       if (this.#fdEnded) {
         return;
       }
@@ -89,13 +87,11 @@ export class Pty {
       // must wait for fd close and exit result before calling real exit
       await fdClosed;
       const result = await exitResult;
-      console.log('calling real exit')
       realExit(result.error, result.code)
     }
 
     this.read.on('end', handleEnd);
     this.read.on('close', () => {
-      console.log('handle close')
       markFdClosed();
     });
 
@@ -115,7 +111,6 @@ export class Pty {
           // EIO only happens when the child dies. It is therefore our only true signal that there
           // is nothing left to read and we can start tearing things down. If we hadn't received an
           // error so far, we are considered to be in good standing.
-          console.log('eio')
           this.read.off('error', handleError);
           handleEnd();
           return;

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -79,6 +79,7 @@ export class Pty {
 
     // catch end events
     const handleEnd = async () => {
+      console.log('handle end')
       if (this.#fdEnded) {
         return;
       }
@@ -94,6 +95,7 @@ export class Pty {
 
     this.read.on('end', handleEnd);
     this.read.on('close', () => {
+      console.log('handle close')
       markFdClosed();
     });
 

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -79,6 +79,7 @@ export class Pty {
         return;
       }
 
+      this.close();
       this.#fdEnded = true;
       exitResult.then((result) => {
         console.log('calling real exit')

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -1,5 +1,5 @@
-import { PassThrough, type Readable, type Writable } from 'node:stream';
-import { ReadStream } from 'node:tty';
+import { type Readable, type Writable } from 'node:stream';
+import { ReadStream, WriteStream } from 'node:tty';
 import {
   Pty as RawPty,
   type Size,
@@ -46,7 +46,6 @@ export class Pty {
   #pty: RawPty;
   #fd: number;
   #fdEnded: boolean = false;
-  #socket: ReadStream;
 
   read: Readable;
   write: Writable;
@@ -70,13 +69,8 @@ export class Pty {
     // Transfer ownership of the FD to us.
     this.#fd = this.#pty.takeFd();
 
-    this.#socket = new ReadStream(this.#fd);
-    // const userFacingRead = new PassThrough();
-    // const userFacingWrite = new PassThrough();
-    // this.#socket.pipe(userFacingRead);
-    // userFacingWrite.pipe(this.#socket);
-    this.read = this.#socket;
-    this.write = this.#socket;
+    this.read = new ReadStream(this.#fd);
+    this.write = new WriteStream(this.#fd);
 
     // catch end events
     const handleClose = () => {
@@ -89,7 +83,7 @@ export class Pty {
         realExit(result.error, result.code)
       });
     };
-    this.#socket.on('close', handleClose);
+    this.read.on('close', handleClose);
 
     // PTYs signal their done-ness with an EIO error. we therefore need to filter them out (as well as
     // cleaning up other spurious errors) so that the user doesn't need to handle them and be in
@@ -107,21 +101,21 @@ export class Pty {
           // EIO only happens when the child dies. It is therefore our only true signal that there
           // is nothing left to read and we can start tearing things down. If we hadn't received an
           // error so far, we are considered to be in good standing.
-          this.#socket.off('error', handleError);
-          this.#socket.end();
+          this.read.off('error', handleError);
+          console.log("EIO")
+          this.write.end();
           return;
         }
       }
-
-      this.read.emit('error', err);
     };
-    this.#socket.on('error', handleError);
+
+    this.read.on('error', handleError);
   }
 
   close() {
     // end instead of destroy so that the user can read the last bits of data
     // and allow graceful close event to mark the fd as ended
-    this.#socket.end();
+    this.write.end();
   }
 
   resize(size: Size) {

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -58,6 +58,7 @@ export class Pty {
       resolve = res;
     });
     const mockedExit = (error: NodeJS.ErrnoException | null, code: number) => {
+      console.log('mocked exit')
       resolve({ error, code });
     };
 
@@ -88,6 +89,7 @@ export class Pty {
 
       ttyStreamEnded = true;
       exitResult.then((result) => {
+        console.log('calling real exit')
         realExit(result.error, result.code)
       });
     }


### PR DESCRIPTION
we shouldnt use passthrough if we dont need it, we got wrecked by the default watermark on the passthrough stream