### PR TITLE
[Bugfix] Ensure writable streams are ended on PTY close

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.4.1",
+      "version": "3.4.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -483,11 +483,7 @@ describe(
       writeStream.write("hello2");
       await expect(errorPromise).rejects.toThrowError(/write after end/);
       
-      // Wait for the onExit callback to be called to ensure all cleanup is done
       await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
-      
-      // Add a small delay to allow file descriptors to be fully closed
-      await new Promise(resolve => setTimeout(resolve, 100));
       
       expect(getOpenFds()).toStrictEqual(oldFds);
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -128,6 +128,7 @@ describe(
     });
 
     test("cannot be written to after closing", async () => {
+      const oldFds = getOpenFds();
       const onExit = vi.fn();
       const pty = new Pty({
         command: '/bin/echo',
@@ -148,6 +149,7 @@ describe(
       expect(writeStream.writable).toBe(false);
       writeStream.write("hello");
       await expect(errorPromise).rejects.toThrowError(/write after end/);
+      expect(getOpenFds()).toStrictEqual(oldFds);
     });
 
     test('can be started in non-interactive fashion', async () => {
@@ -169,9 +171,6 @@ describe(
       await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
       expect(onExit).toHaveBeenCalledWith(null, 0);
 
-      // Add a delay to allow for file descriptor cleanup
-      await new Promise(resolve => setTimeout(resolve, 100));
-      
       let result = buffer.toString();
       const expectedResult = '\r\n';
       expect(result.trim()).toStrictEqual(expectedResult.trim());

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -45,7 +45,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe.sequential(
+describe(
   'PTY',
   { repeats: 500 },
   () => {
@@ -124,31 +124,6 @@ describe.sequential(
 
       const expectedResult = 'hello cat\r\nhello cat\r\n';
       expect(result.trim()).toStrictEqual(expectedResult.trim());
-      expect(getOpenFds()).toStrictEqual(oldFds);
-    });
-
-    test("cannot be written to after closing", async () => {
-      const oldFds = getOpenFds();
-      const onExit = vi.fn();
-      const pty = new Pty({
-        command: '/bin/echo',
-        args: ['hello'],
-        onExit,
-      });
-
-      const writeStream = pty.write;
-
-      const errorPromise = new Promise<void>((resolve, reject) => {
-        writeStream.on('error', (error) => {
-          reject(error);
-        });
-      });
-
-      pty.close();
-
-      expect(writeStream.writable).toBe(false);
-      writeStream.write("hello");
-      await expect(errorPromise).rejects.toThrowError(/write after end/);
       expect(getOpenFds()).toStrictEqual(oldFds);
     });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -185,7 +185,7 @@ describe(
             // Add a small delay to ensure the resize has taken effect
             setTimeout(() => {
               writeStream.write("stty size; echo 'done2'\n");
-            }, 50);
+            }, 100);
             return;
           }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -482,8 +482,6 @@ describe(
       assert(!writeStream.writable)
       writeStream.write("hello2");
       await expect(errorPromise).rejects.toThrowError(/write after end/);
-
-      process.kill(pty.pid, 'SIGKILL');
       expect(getOpenFds()).toStrictEqual(oldFds);
     });
   },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -70,6 +70,8 @@ describe(
       expect(onExit).toHaveBeenCalledWith(null, 0);
       expect(buffer.trim()).toBe(message);
       expect(getOpenFds()).toStrictEqual(oldFds);
+      expect(pty.write.writable).toBe(false);
+      expect(pty.read.readable).toBe(false);
     });
 
     test('captures an exit code', async () => {
@@ -112,6 +114,7 @@ describe(
 
       await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
       expect(onExit).toHaveBeenCalledWith(null, 0);
+      expect(pty.write.writable).toBe(false);
       
       let result = buffer.toString();
       if (IS_DARWIN) {
@@ -281,6 +284,8 @@ describe(
       process.kill(pty.pid, 'SIGKILL');
       await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
       expect(onExit).toHaveBeenCalledWith(null, -1);
+      expect(pty.write.writable).toBe(false);
+      expect(pty.read.readable).toBe(false);
     });
 
     test(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -182,10 +182,7 @@ describe(
             expect(buffer).toContain('24 80');
             pty.resize({ rows: 60, cols: 100 });
 
-            // Add a delay to ensure the resize has taken effect
-            setTimeout(() => {
-              writeStream.write("stty size; echo 'done2'\n");
-            }, 200);
+            writeStream.write("stty size; echo 'done2'\n");
             return;
           }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -168,6 +168,10 @@ describe(
 
       await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
       expect(onExit).toHaveBeenCalledWith(null, 0);
+
+      // Add a delay to allow for file descriptor cleanup
+      await new Promise(resolve => setTimeout(resolve, 100));
+      
       let result = buffer.toString();
       const expectedResult = '\r\n';
       expect(result.trim()).toStrictEqual(expectedResult.trim());

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -182,7 +182,10 @@ describe(
             expect(buffer).toContain('24 80');
             pty.resize({ rows: 60, cols: 100 });
 
-            writeStream.write("stty size; echo 'done2'\n");
+            // Add a small delay to ensure the resize has taken effect
+            setTimeout(() => {
+              writeStream.write("stty size; echo 'done2'\n");
+            }, 50);
             return;
           }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -184,7 +184,7 @@ describe(
 
             // Add a delay to ensure the resize has taken effect
             setTimeout(() => {
-              writeStream.write("stty size; echo ' '\n");
+              writeStream.write("stty size; echo 'done2'\n");
             }, 200);
             return;
           }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -182,10 +182,10 @@ describe(
             expect(buffer).toContain('24 80');
             pty.resize({ rows: 60, cols: 100 });
 
-            // Add a small delay to ensure the resize has taken effect
+            // Add a delay to ensure the resize has taken effect
             setTimeout(() => {
-              writeStream.write("stty size; echo 'done2'\n");
-            }, 100);
+              writeStream.write("stty size; echo ' '\n");
+            }, 200);
             return;
           }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -47,7 +47,7 @@ function getOpenFds(): FdRecord {
 
 describe.sequential(
   'PTY',
-  // { repeats: 500 },
+  { repeats: 500 },
   () => {
     test('spawns and exits', async () => {
       const oldFds = getOpenFds();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -45,9 +45,9 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe(
+describe.sequential(
   'PTY',
-  { repeats: 500 },
+  // { repeats: 500 },
   () => {
     test('spawns and exits', async () => {
       const oldFds = getOpenFds();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -482,6 +482,13 @@ describe(
       assert(!writeStream.writable)
       writeStream.write("hello2");
       await expect(errorPromise).rejects.toThrowError(/write after end/);
+      
+      // Wait for the onExit callback to be called to ensure all cleanup is done
+      await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
+      
+      // Add a small delay to allow file descriptors to be fully closed
+      await new Promise(resolve => setTimeout(resolve, 100));
+      
       expect(getOpenFds()).toStrictEqual(oldFds);
     });
   },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -457,7 +457,7 @@ describe(
       expect(getOpenFds()).toStrictEqual(oldFds);
     });
 
-    test.only("cannot be written to after closing", async () => {
+    test("cannot be written to after closing", async () => {
       const oldFds = getOpenFds();
       const onExit = vi.fn();
       const pty = new Pty({

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -45,7 +45,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe(
+describe.sequential(
   'PTY',
   { repeats: 500 },
   () => {

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -95,6 +95,7 @@ export class Pty {
       }
 
       this.#fdClosed = true;
+      this.#writable.end();
 
       // must wait for fd close and exit result before calling real exit
       await readFinished;
@@ -141,6 +142,7 @@ export class Pty {
     // end instead of destroy so that the user can read the last bits of data
     // and allow graceful close event to mark the fd as ended
     this.#socket.end();
+    this.#writable.end();
   }
 
   resize(size: Size) {


### PR DESCRIPTION
### What is this PR?

The writable stream in PTY is never set to 'unwritable' when PTY is closed or when the child process dies.

### Changes

- Add `this.#writable.end()` in `close()` and `exit()` methods of Pty class
- Update tests to verify write and read streams are no longer writable/readable after PTY closes