### PR TITLE
Ignore os error 25(ENOTTY)

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.4.3",
+      "version": "3.4.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -155,10 +155,13 @@ export class Pty {
     } catch (e: unknown) {
       // napi-rs only throws strings so we must string match here
       // https://docs.rs/napi/latest/napi/struct.Error.html#method.new
-      if (e instanceof Error && e.message.indexOf('os error 9') !== -1) {
-        // error 9 is EBADF
-        // EBADF means the file descriptor is invalid. This can happen if the PTY has already
-        // exited but we don't know about it yet. In that case, we just ignore the error.
+      if (e instanceof Error && 
+         (e.message.indexOf('os error 9') !== -1 || // EBADF
+          e.message.indexOf('os error 25') !== -1)) { // ENOTTY
+        // error 9 is EBADF (bad file descriptor)
+        // error 25 is ENOTTY (inappropriate ioctl for device)
+        // These can happen if the PTY has already exited or wasn't a terminal device
+        // In that case, we just ignore the error.
         return;
       }
 


### PR DESCRIPTION
### Changes
- Updated error handling in the `Pty` class to also ignore 'os error 25' (ENOTTY) in addition to 'os error 9' (EBADF) when the PTY has exited or is not a terminal device.