### PR TITLE
Updated the write getter to return the socket as Writable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,17 +20,17 @@ export interface Size {
   rows: number;
 }
 /** Resize the terminal. */
-export function ptyResize(fd: number, size: Size): void;
+export declare function ptyResize(fd: number, size: Size): void;
 /**
  * Set the close-on-exec flag on a file descriptor. This is `fcntl(fd, F_SETFD, FD_CLOEXEC)` under
  * the covers.
  */
-export function setCloseOnExec(fd: number, closeOnExec: boolean): void;
+export declare function setCloseOnExec(fd: number, closeOnExec: boolean): void;
 /**
  * Get the close-on-exec flag on a file descriptor. This is `fcntl(fd, F_GETFD) & FD_CLOEXEC ==
  *_CLOEXEC` under the covers.
  */
-export function getCloseOnExec(fd: number): boolean;
+export declare function getCloseOnExec(fd: number): boolean;
 export declare class Pty {
   /** The pid of the forked process. */
   pid: number;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@
 
 const { existsSync, readFileSync } = require('fs')
 const { join } = require('path');
+const { createRequire } = require('node:module');
+require = createRequire(__filename);
 
 const { platform, arch } = process;
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@
 
 const { existsSync, readFileSync } = require('fs')
 const { join } = require('path');
-const { createRequire } = require('node:module');
-require = createRequire(__filename);
 
 const { platform, arch } = process;
 

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -471,20 +471,17 @@ describe(
 
       readStream.on('data', () => {});
 
-      const errorPromise = new Promise<void>((resolve, reject) => {
-        writeStream.on('error', (error) => {
-          reject(error);
-        });
-      });
-
       pty.close();
 
       assert(!writeStream.writable)
-      writeStream.write("hello2");
-      await expect(errorPromise).rejects.toThrowError(/write after end/);
-      
       await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
-      
+      let receivedError = false;
+      writeStream.write("hello2", (error) => {
+        if (error) {
+          receivedError = true;
+        }
+      });
+      await vi.waitFor(() => receivedError);
       expect(getOpenFds()).toStrictEqual(oldFds);
     });
   },

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -1,4 +1,4 @@
-import { type Readable, type Writable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 import { ReadStream } from 'node:tty';
 import {
   Pty as RawPty,


### PR DESCRIPTION
#### What is this change?

Instead of trying to wrap the tty `ReadStream` with `Writable` and sync the states, we can just return the `ReadStream` as a `Writable` in the `write` getter. In this case, when the fd is closed or destroyed, the `writable` will also be `closed`.

