### PR TITLE
[safe-vibe-coding] Properly re-export all the sandbox types

### DIFF
--- a/index.js
+++ b/index.js
@@ -321,11 +321,11 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`);
 }
 
-const { Operation, Pty, ptyResize, setCloseOnExec, getCloseOnExec } =
+const { Pty, Operation, ptyResize, setCloseOnExec, getCloseOnExec } =
   nativeBinding;
 
-module.exports.Operation = Operation;
 module.exports.Pty = Pty;
+module.exports.Operation = Operation;
 module.exports.ptyResize = ptyResize;
 module.exports.setCloseOnExec = setCloseOnExec;
 module.exports.getCloseOnExec = getCloseOnExec;

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "os": [
     "linux"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.6",
+  "version": "3.4.7",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",
@@ -48,8 +48,8 @@
     "format": "npx prettier *.{js,ts} tests/*.ts --write"
   },
   "optionalDependencies": {
-    "@replit/ruspty-darwin-x64": "3.4.6",
-    "@replit/ruspty-darwin-arm64": "3.4.6",
-    "@replit/ruspty-linux-x64-gnu": "3.4.6"
+    "@replit/ruspty-darwin-x64": "3.4.7",
+    "@replit/ruspty-darwin-arm64": "3.4.7",
+    "@replit/ruspty-linux-x64-gnu": "3.4.7"
   }
 }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -7,9 +7,14 @@ import {
   getCloseOnExec as rawGetCloseOnExec,
   ptyResize,
 } from './index.js';
-import { type PtyOptions as RawOptions } from './index.js';
+import {
+  type PtyOptions,
+  Operation,
+  type SandboxRule,
+  type SandboxOptions,
+} from './index.js';
 
-export type PtyOptions = RawOptions;
+export { Operation, type SandboxRule, type SandboxOptions, type PtyOptions };
 
 type ExitResult = {
   error: NodeJS.ErrnoException | null;


### PR DESCRIPTION
We apparently need these for the client.

Add these.