### PR TITLE
Add range check in resize

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -492,6 +492,46 @@ describe('PTY', { repeats: 500 }, () => {
     await vi.waitFor(() => receivedError);
     expect(getOpenFds()).toStrictEqual(oldFds);
   });
+
+  test('cannot resize when out of range', async () => {
+    const oldFds = getOpenFds();
+    let buffer = '';
+
+    const onExit = vi.fn();
+    const pty = new Pty({
+      command: '/bin/sh',
+      size: { rows: 24, cols: 80 },
+      onExit,
+    });
+
+    pty.read.on('data', () => {});
+
+    expect(() => pty.resize({ rows: 1, cols: -1 })).toThrow(RangeError);
+    expect(() => pty.resize({ rows: 1, cols: -1 })).toThrow(
+      /Size \(1x-1\) out of range/,
+    );
+
+    expect(() => pty.resize({ rows: 1, cols: 99999 })).toThrow(RangeError);
+    expect(() => pty.resize({ rows: 1, cols: 99999 })).toThrow(
+      /Size \(1x99999\) out of range/,
+    );
+
+    expect(() => pty.resize({ rows: -1, cols: 1 })).toThrow(RangeError);
+    expect(() => pty.resize({ rows: -1, cols: 1 })).toThrow(
+      /Size \(-1x1\) out of range/,
+    );
+
+    expect(() => pty.resize({ rows: 99999, cols: 1 })).toThrow(RangeError);
+    expect(() => pty.resize({ rows: 99999, cols: 1 })).toThrow(
+      /Size \(99999x1\) out of range/,
+    );
+
+    process.kill(pty.pid, 'SIGKILL');
+
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
+    expect(onExit).toHaveBeenCalledWith(null, -1);
+    expect(getOpenFds()).toStrictEqual(oldFds);
+  });
 });
 
 describe('cgroup opts', () => {

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -21,6 +21,9 @@ type ExitResult = {
   code: number;
 };
 
+export const MIN_SIZE = 0;
+export const MAX_SIZE = 65535; // max value of u16
+
 /**
  * A very thin wrapper around PTYs and processes.
  *
@@ -114,7 +117,7 @@ export class Pty {
         const code = err.code;
         if (code === 'EINTR' || code === 'EAGAIN') {
           // these two are expected. EINTR happens when the kernel restarts a `read(2)`/`write(2)`
-          // syscall due to it being interrupted by another syscall, and EAGAIN happens when there
+          // syscall due to it being interrupted by another syscall, and E$AGAIN happens when there
           // is no more data to be read by the fd.
           return;
         } else if (code.indexOf('EIO') !== -1) {
@@ -147,6 +150,17 @@ export class Pty {
   resize(size: Size) {
     if (this.#handledClose || this.#fdClosed) {
       return;
+    }
+
+    if (
+      size.cols < MIN_SIZE ||
+      size.cols > MAX_SIZE ||
+      size.rows < MIN_SIZE ||
+      size.rows > MAX_SIZE
+    ) {
+      throw new RangeError(
+        `Size (${size.rows}x${size.cols}) out of range: must be between ${MIN_SIZE} and ${MAX_SIZE}`,
+      );
     }
 
     try {


### PR DESCRIPTION
### Why?

If user input size that's out of range for `u16` type, it will throw an `Failed to convert u32 to u16` error.

### What changed

- Check size input and throw a more detailed error when it is out of range.