### PR TITLE
Remove optionalDependencies in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,6 @@
         "tsup": "^8.3.5",
         "typescript": "^5.4.5",
         "vitest": "^1.6.1"
-      },
-      "optionalDependencies": {
-        "@replit/ruspty-darwin-arm64": "3.4.9",
-        "@replit/ruspty-darwin-x64": "3.4.9",
-        "@replit/ruspty-linux-x64-gnu": "3.4.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -722,54 +717,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@replit/ruspty-darwin-arm64": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-arm64/-/ruspty-darwin-arm64-3.4.9.tgz",
-      "integrity": "sha512-3CNJ6N43HqnZNm1EZTB/ZVSUDM6MXuZ0R4C6V7WZrAbdJvjmVKGYToGtQJ8GSivae0fktqWHGS7eD1lW/R5jUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@replit/ruspty-darwin-x64": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-x64/-/ruspty-darwin-x64-3.4.9.tgz",
-      "integrity": "sha512-tyfSykuhjNhrgb/McxuG6mST+WvGZO+slPUq1y3ODkYLiXDNcfkCDssmqw+Ei5cMgF6gfC4oWRu/sBXdycvzEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@replit/ruspty-linux-x64-gnu": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-linux-x64-gnu/-/ruspty-linux-x64-gnu-3.4.9.tgz",
-      "integrity": "sha512-7Ps4z8Fy8k8+k/P4juHgX+Tl6H/KMrLxgpRRPTU6GqQxrmhs7i2ShD+1o5ZbeHRQCPHz3yzEEv96eayr7qj51Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "vitest": "^1.6.1"
       },
       "optionalDependencies": {
-        "@replit/ruspty-darwin-arm64": "3.4.7",
-        "@replit/ruspty-darwin-x64": "3.4.7",
-        "@replit/ruspty-linux-x64-gnu": "3.4.7"
+        "@replit/ruspty-darwin-arm64": "3.4.9",
+        "@replit/ruspty-darwin-x64": "3.4.9",
+        "@replit/ruspty-linux-x64-gnu": "3.4.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -725,12 +725,13 @@
       }
     },
     "node_modules/@replit/ruspty-darwin-arm64": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-arm64/-/ruspty-darwin-arm64-3.4.7.tgz",
-      "integrity": "sha512-5ZFJHjIzjOzzf9E00R5+pl9RH/9FQUMn96LN50fHPk1FqBstFo7pyp1jSeMHBW9++rfQ2zDHPCvJSsRNhg2V9w==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-arm64/-/ruspty-darwin-arm64-3.4.9.tgz",
+      "integrity": "sha512-3CNJ6N43HqnZNm1EZTB/ZVSUDM6MXuZ0R4C6V7WZrAbdJvjmVKGYToGtQJ8GSivae0fktqWHGS7eD1lW/R5jUw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -740,12 +741,13 @@
       }
     },
     "node_modules/@replit/ruspty-darwin-x64": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-x64/-/ruspty-darwin-x64-3.4.7.tgz",
-      "integrity": "sha512-RQ54b32Dx7ge10WNhMxzVlSH+HmHf0TG/WFkRbxareZ2K9DRGzMvrKzJ7Md7i4/FZXj/PHB3fxhn4SpI/18rdg==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-x64/-/ruspty-darwin-x64-3.4.9.tgz",
+      "integrity": "sha512-tyfSykuhjNhrgb/McxuG6mST+WvGZO+slPUq1y3ODkYLiXDNcfkCDssmqw+Ei5cMgF6gfC4oWRu/sBXdycvzEw==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -755,12 +757,13 @@
       }
     },
     "node_modules/@replit/ruspty-linux-x64-gnu": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-linux-x64-gnu/-/ruspty-linux-x64-gnu-3.4.7.tgz",
-      "integrity": "sha512-CjagF32RJ9wK2Vzw6KD4YF/KdXuYR2EDeT5y6dAi0cpBfrpbbSS/q81Xg1GUUsSwxus4bn8UgTmDR/W87vlXbw==",
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/@replit/ruspty-linux-x64-gnu/-/ruspty-linux-x64-gnu-3.4.9.tgz",
+      "integrity": "sha512-7Ps4z8Fy8k8+k/P4juHgX+Tl6H/KMrLxgpRRPTU6GqQxrmhs7i2ShD+1o5ZbeHRQCPHz3yzEEv96eayr7qj51Q==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"

--- a/package.json
+++ b/package.json
@@ -46,10 +46,5 @@
     "version": "napi version",
     "release": "npm publish --access public",
     "format": "npx prettier *.{js,ts} tests/*.ts --write"
-  },
-  "optionalDependencies": {
-    "@replit/ruspty-darwin-x64": "3.4.9",
-    "@replit/ruspty-darwin-arm64": "3.4.9",
-    "@replit/ruspty-linux-x64-gnu": "3.4.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "format": "npx prettier *.{js,ts} tests/*.ts --write"
   },
   "optionalDependencies": {
-    "@replit/ruspty-darwin-x64": "3.4.7",
-    "@replit/ruspty-darwin-arm64": "3.4.7",
-    "@replit/ruspty-linux-x64-gnu": "3.4.7"
+    "@replit/ruspty-darwin-x64": "3.4.9",
+    "@replit/ruspty-darwin-arm64": "3.4.9",
+    "@replit/ruspty-linux-x64-gnu": "3.4.9"
   }
 }


### PR DESCRIPTION
### Why?

`optionalDependencies` was added in `v3.4.5`, but it is causing issue when importing ruspty in a new project because it adds those lines in `wrapper.js`

```js
// node_modules/@replit/ruspty-linux-x64-gnu/ruspty.linux-x64-gnu.node
var require_ruspty_linux_x64_gnu = __commonJS({
  "node_modules/@replit/ruspty-linux-x64-gnu/ruspty.linux-x64-gnu.node"(exports2, module2) {
    module2.exports = "./ruspty.linux-x64-gnu-AEYDU72I.node";
  }
});
```

example project: https://replit.com/t/replit/repls/ruspty-optional-depedencies?replId=60aaaa85-df32-49d5-b62c-ec9860b0cb44#index.ts

### What changed?

- remove optionalDependencies


