### PR TITLE
[safe-vibe-coding] Prevent leaking FDs

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.4.9",
+      "version": "3.4.10",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",
@@ -17,11 +17,6 @@
         "tsup": "^8.3.5",
         "typescript": "^5.4.5",
         "vitest": "^1.6.1"
-      },
-      "optionalDependencies": {
-        "@replit/ruspty-darwin-arm64": "3.4.7",
-        "@replit/ruspty-darwin-x64": "3.4.7",
-        "@replit/ruspty-linux-x64-gnu": "3.4.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -722,51 +717,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@replit/ruspty-darwin-arm64": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-arm64/-/ruspty-darwin-arm64-3.4.7.tgz",
-      "integrity": "sha512-5ZFJHjIzjOzzf9E00R5+pl9RH/9FQUMn96LN50fHPk1FqBstFo7pyp1jSeMHBW9++rfQ2zDHPCvJSsRNhg2V9w==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@replit/ruspty-darwin-x64": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-darwin-x64/-/ruspty-darwin-x64-3.4.7.tgz",
-      "integrity": "sha512-RQ54b32Dx7ge10WNhMxzVlSH+HmHf0TG/WFkRbxareZ2K9DRGzMvrKzJ7Md7i4/FZXj/PHB3fxhn4SpI/18rdg==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@replit/ruspty-linux-x64-gnu": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@replit/ruspty-linux-x64-gnu/-/ruspty-linux-x64-gnu-3.4.7.tgz",
-      "integrity": "sha512-CjagF32RJ9wK2Vzw6KD4YF/KdXuYR2EDeT5y6dAi0cpBfrpbbSS/q81Xg1GUUsSwxus4bn8UgTmDR/W87vlXbw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.9",
+  "version": "3.4.10",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",
@@ -46,10 +46,5 @@
     "version": "napi version",
     "release": "npm publish --access public",
     "format": "npx prettier *.{js,ts} tests/*.ts --write"
-  },
-  "optionalDependencies": {
-    "@replit/ruspty-darwin-x64": "3.4.7",
-    "@replit/ruspty-darwin-arm64": "3.4.7",
-    "@replit/ruspty-linux-x64-gnu": "3.4.7"
   }
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -565,6 +565,7 @@ async function getCgroupState(): Promise<CgroupState> {
 async function cgroupInit(cgroupState: CgroupState) {
   // create the slice - this is the cgroup that will be used for testing
   await exec(`sudo mkdir -p ${cgroupState.sliceDir}`);
+  await exec(`sudo chown -R $(id -u):$(id -g) ${cgroupState.sliceDir}`);
 
   // add the current process to the slice
   // so the spawned pty inherits the slice - this is important because


### PR DESCRIPTION
We had a problem in the past where the middle process was holding onto some file descriptors unnecessarily.

This change now makes the middle process close all file descriptors immediately after forking so that the total number of references to those files stays as it is expected.