### PR TITLE
Use container to build artifacts

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,7 @@ jobs:
           strip -x *.node
         shell: bash
       - name: Dump GLIBC symbols
+        if: matrix.settings.host == 'ubuntu-24.04'
         run: |
           objdump -T *.node | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu > glibc_versions.txt
           

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,10 +36,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
             container: ubuntu:20.04
             description: 'Container (ubuntu:20.04)'
-          - host: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-            container: ubuntu:24.04
-            description: 'Container (ubuntu:24.04)'
     name: Build and test on ${{ matrix.settings.target }} (${{ matrix.settings.description }})
     runs-on: ${{ matrix.settings.host }}
     container: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,12 +28,19 @@ jobs:
         settings:
           - host: macos-14-large
             target: x86_64-apple-darwin
+            description: 'macOS 14 (x86_64)'
           - host: macos-latest
             target: aarch64-apple-darwin
+            description: 'macOS Latest (ARM64)'
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             container: ubuntu:20.04
-    name: Build and test on ${{ matrix.settings.target }}
+            description: 'Container (ubuntu:20.04)'
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            container: ubuntu:24.04
+            description: 'Container (ubuntu:24.04)'
+    name: Build and test on ${{ matrix.settings.target }} (${{ matrix.settings.description }})
     runs-on: ${{ matrix.settings.host }}
     container: 
       image: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
         if: matrix.settings.host == 'ubuntu-24.04'
         run: |
           apt-get update
-          apt-get install -y curl build-essential
+          apt-get install -y curl build-essential sudo
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,30 +21,32 @@ permissions:
   pull_request: null
 
 jobs:
-  build-test:
+  build:
     strategy:
       fail-fast: false
       matrix:
         settings:
           - host: macos-14-large
             target: x86_64-apple-darwin
+            description: "macOS 14"
           - host: macos-latest
             target: aarch64-apple-darwin
+            description: "macOS latest"
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             container: ubuntu:20.04
-    name: Build and test on ${{ matrix.settings.target }} (${{ matrix.settings.description }})
+            description: "Ubuntu Container(20.04)"
+    name: Build ${{ matrix.settings.target }} on (${{ matrix.settings.description }})
     runs-on: ${{ matrix.settings.host }}
-    container: 
+    container:
       image: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}
-      options: --privileged
     steps:
       - uses: actions/checkout@v4
       - name: Install container dependencies
         if: matrix.settings.host == 'ubuntu-24.04'
         run: |
           apt-get update
-          apt-get install -y curl build-essential sudo cgroup-tools coreutils
+          apt-get install -y curl build-essential
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -87,8 +89,6 @@ jobs:
             fi
           fi
         shell: bash
-      - name: Test bindings
-        run: npm run test:ci
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -96,13 +96,59 @@ jobs:
           path: ${{ env.APP_NAME }}.*.node
           if-no-files-found: error
 
+  test:
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-14-large
+            target: x86_64-apple-darwin
+            description: "macOS 14"
+          - host: macos-latest
+            target: aarch64-apple-darwin
+            description: "macOS latest"
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            container: ubuntu:20.04
+            description: "Ubuntu Container(20.04)"
+          - host: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            container: ubuntu:24.04
+            description: "Ubuntu Container(24.04)"
+    name: Test on ${{ matrix.settings.target }} (${{ matrix.settings.description }})
+    runs-on: ${{ matrix.settings.host }}
+    container: 
+      image: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install container dependencies
+        if: matrix.settings.host == 'ubuntu-24.04'
+        run: |
+          apt-get update
+          apt-get install -y curl build-essential sudo cgroup-tools coreutils
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # Ubuntu 24.04 container will use the same artifact built on 20.04
+          name: ${{ matrix.settings.container == 'ubuntu:24.04' ? 'bindings-x86_64-unknown-linux-gnu' : format('bindings-{0}', matrix.settings.target) }}
+      - name: Test bindings
+        run: npm run test:ci
+
   publish:
     name: Publish
     runs-on: ubuntu-24.04
     container: ubuntu:20.04
     if: github.ref == 'refs/heads/main'
     needs:
-      - build-test
+      - test
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -138,7 +138,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Ubuntu 24.04 container will use the same artifact built on 20.04
-          name: ${{ matrix.settings.container == 'ubuntu:24.04' ? 'bindings-x86_64-unknown-linux-gnu' : format('bindings-{0}', matrix.settings.target) }}
+          name: ${{ matrix.settings.container == 'ubuntu:24.04' ? 'bindings-x86_64-unknown-linux-gnu' : 'bindings-' + matrix.settings.target }}
       - name: Test bindings
         run: npm run test:ci
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,11 @@ jobs:
     container: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}
     steps:
       - uses: actions/checkout@v4
+      - name: Install container dependencies
+        if: matrix.settings.host == 'ubuntu-24.04'
+        run: |
+          apt-get update
+          apt-get install -y curl build-essential
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,8 +32,10 @@ jobs:
             target: aarch64-apple-darwin
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            container: ubuntu:20.04
     name: Build and test on ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
+    container: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
@@ -64,7 +66,19 @@ jobs:
           strip -x *.node
         shell: bash
       - name: Dump GLIBC symbols
-        run: objdump -T *.node | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu
+        run: |
+          objdump -T *.node | grep GLIBC | sed 's/.*GLIBC_\([.0-9]*\).*/\1/g' | sort -Vu > glibc_versions.txt
+          
+          if [ -s glibc_versions.txt ]; then
+            MAX_VERSION=$(cat glibc_versions.txt | sort -V | tail -n 1)
+            echo "Highest GLIBC version: $MAX_VERSION"
+            
+            if [ "$(echo "$MAX_VERSION 2.29" | awk '{if ($1 > $2) print "1"; else print "0"}')" -eq 1 ]; then
+              echo "Error: GLIBC version $MAX_VERSION is larger than 2.29"
+              exit 1
+            fi
+          fi
+        shell: bash
       - name: Test bindings
         run: npm run test:ci
       - name: Upload artifact
@@ -77,6 +91,7 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-24.04
+    container: ubuntu:20.04
     if: github.ref == 'refs/heads/main'
     needs:
       - build-test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,10 +135,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Download build artifacts
+        # Special case for Ubuntu 24.04 - reuse the 20.04 artifacts
+        if: matrix.settings.container == 'ubuntu:24.04'
         uses: actions/download-artifact@v4
         with:
-          # Ubuntu 24.04 container will use the same artifact built on 20.04
-          name: ${{ matrix.settings.container == 'ubuntu:24.04' ? 'bindings-x86_64-unknown-linux-gnu' : 'bindings-' + matrix.settings.target }}
+          name: bindings-x86_64-unknown-linux-gnu
+
+      - name: Download build artifacts
+        # For all other platforms - use the matching bindings
+        if: matrix.settings.container != 'ubuntu:24.04'
+        uses: actions/download-artifact@v4
+        with:
+          name: bindings-${{ matrix.settings.target }}
+      
       - name: Test bindings
         run: npm run test:ci
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,14 +28,11 @@ jobs:
         settings:
           - host: macos-14-large
             target: x86_64-apple-darwin
-            description: 'macOS 14 (x86_64)'
           - host: macos-latest
             target: aarch64-apple-darwin
-            description: 'macOS Latest (ARM64)'
           - host: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             container: ubuntu:20.04
-            description: 'Container (ubuntu:20.04)'
     name: Build and test on ${{ matrix.settings.target }} (${{ matrix.settings.description }})
     runs-on: ${{ matrix.settings.host }}
     container: 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,7 +47,7 @@ jobs:
         if: matrix.settings.host == 'ubuntu-24.04'
         run: |
           apt-get update
-          apt-get install -y curl build-essential sudo cgroup-tools
+          apt-get install -y curl build-essential sudo cgroup-tools coreutils
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,14 +35,16 @@ jobs:
             container: ubuntu:20.04
     name: Build and test on ${{ matrix.settings.target }}
     runs-on: ${{ matrix.settings.host }}
-    container: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}
+    container: 
+      image: ${{ matrix.settings.host == 'ubuntu-24.04' && matrix.settings.container || '' }}
+      options: --privileged
     steps:
       - uses: actions/checkout@v4
       - name: Install container dependencies
         if: matrix.settings.host == 'ubuntu-24.04'
         run: |
           apt-get update
-          apt-get install -y curl build-essential sudo
+          apt-get install -y curl build-essential sudo cgroup-tools
       - name: Setup node
         uses: actions/setup-node@v4
         with:

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.4.10",
+      "version": "3.4.11",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.10",
+  "version": "3.4.11",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,7 +57,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 500 }, () => {
+describe('PTY', { repeats: 0 }, () => {
   test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -186,7 +186,7 @@ describe('PTY', { repeats: 0 }, () => {
         console.log('reading from pty', data.toString());
         buffer += data.toString();
 
-        if (state === 'expectPrompt' && buffer.endsWith('$ ')) {
+        if (state === 'expectPrompt' && (buffer.endsWith('$ ') || buffer.endsWith('# '))) {
           writeStream.write("stty size; echo 'done1'\n");
           state = 'expectDone1';
           return;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,7 +57,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 0 }, () => {
+describe('PTY', { repeats: 500 }, () => {
   test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -161,7 +161,7 @@ describe('PTY', { repeats: 0 }, () => {
     expect(getOpenFds()).toStrictEqual(oldFds);
   });
 
-  test.only('can be resized', async () => {
+  test('can be resized', async () => {
     const oldFds = getOpenFds();
     let buffer = '';
     let state: 'expectPrompt' | 'expectDone1' | 'expectDone2' | 'done' =

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -544,13 +544,11 @@ type CgroupState = {
 };
 
 async function detectCgroupVersion(): Promise<'v1' | 'v2'> {
-  try {
-    // Check for the unified hierarchy mount, characteristic of v2
-    await exec('mountpoint -q /sys/fs/cgroup/unified');
-    return 'v2';
-  } catch (e) {
+    const cgroupRaw = (await exec('grep cgroup /proc/filesystems')).stdout.trim();
+    if (cgroupRaw.includes('cgroup2')) {
+      return 'v2';
+    }
     return 'v1';
-  }
 }
 
 async function getCgroupState(): Promise<CgroupState> {


### PR DESCRIPTION
### Why?

Ubuntu 24.04 uses `glibc 2.39` while we want to keep using `glibc 2.29` as before when compiling the native code.

### What changed?

- Use `ubuntu:20.04` docker image for building and testing step
- Update the cgroup test to support both cgroup v1 and cgroup v2 because Ubuntu 20.04 uses v1 but still want to keep the ability to run the tests on a system with v2