### PR TITLE
[safe-vibe-coding] Allow the AppArmor transition to fail

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,7 @@ export interface PtyOptions {
   dir?: string;
   size?: Size;
   cgroupPath?: string;
+  apparmorProfile?: string;
   interactive?: boolean;
   sandbox?: SandboxOptions;
   onExit: (err: null | Error, exitCode: number) => void;

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.4.14",
+      "version": "3.4.15",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.4.14",
+  "version": "3.4.15",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,10 +294,11 @@ impl Pty {
         // Set the AppArmor profile.
         #[cfg(target_os = "linux")]
         if let Some(apparmor_profile) = &opts.apparmor_profile {
-          write(
+          // TODO: Make this fail once we're sure we're never going back.
+          let _ = write(
             "/proc/self/attr/apparmor/exec",
             format!("exec {apparmor_profile}"),
-          )?;
+          );
         }
 
         // set input modes

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -537,8 +537,8 @@ describe('PTY', { repeats: 500 }, () => {
   });
 });
 
-type CgroupState = 
-  | { 
+type CgroupState =
+  | {
       version: 'v1';
       sliceDir: string; // Full path for v1 group using primary subsystem (e.g., "/sys/fs/cgroup/cpu/ruspty-xyz")
       originalCgroup?: string; // Path within each hierarchy (e.g., "/user.slice")
@@ -605,7 +605,7 @@ async function getCgroupState(): Promise<CgroupState> {
 
     return {
       version,
-      sliceDir: `/sys/fs/cgroup/${v1Subsystems[0]}/${sliceBaseName}`, 
+      sliceDir: `/sys/fs/cgroup/${v1Subsystems[0]}/${sliceBaseName}`,
       originalCgroup, // Path relative to subsystem root
       sliceName: sliceBaseName, // Base name
       moved: false,


### PR DESCRIPTION
During the intermediate period, we want the AppArmor profile transition to sometimes fail.

This change makes it possible for the process to continue even if the transition fails instead of breaking everything.