### PR TITLE
dont drop user fd until node reads a synthetic EOF

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,10 @@ export declare class Pty {
    * once (it will error the second time). The caller is responsible for closing the file
    * descriptor.
    */
-  takeFd(): c_int;
-  closeUserFd(): void;
+  takeControllerFd(): c_int;
+  /**
+   * Closes the owned file descriptor for the PTY controller. The Nodejs side must call this
+   * when it is done with the file descriptor to avoid leaking FDs.
+   */
+  dropUserFd(): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,6 @@ export interface PtyOptions {
   apparmorProfile?: string;
   interactive?: boolean;
   sandbox?: SandboxOptions;
-  exitOutputStabilityPeriod?: number;
   onExit: (err: null | Error, exitCode: number) => void;
 }
 /** A size struct to pass to resize. */
@@ -62,7 +61,6 @@ export declare class Pty {
   /** The pid of the forked process. */
   pid: number;
   constructor(opts: PtyOptions);
-  areFdsEmpty(controllerFd: c_int): boolean;
   /**
    * Transfers ownership of the file descriptor for the PTY controller. This can only be called
    * once (it will error the second time). The caller is responsible for closing the file

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ export interface Size {
 }
 export const MAX_U16_VALUE: number;
 export const MIN_U16_VALUE: number;
+export declare function getSyntheticEofSequence(): Buffer;
 /** Resize the terminal. */
 export declare function ptyResize(fd: number, size: Size): void;
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,4 +67,5 @@ export declare class Pty {
    * descriptor.
    */
   takeFd(): c_int;
+  closeUserFd(): void;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,7 @@ export interface PtyOptions {
   apparmorProfile?: string;
   interactive?: boolean;
   sandbox?: SandboxOptions;
+  exitOutputStabilityPeriod?: number;
   onExit: (err: null | Error, exitCode: number) => void;
 }
 /** A size struct to pass to resize. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,7 @@ export declare class Pty {
   /** The pid of the forked process. */
   pid: number;
   constructor(opts: PtyOptions);
+  areFdsEmpty(controllerFd: c_int): boolean;
   /**
    * Transfers ownership of the file descriptor for the PTY controller. This can only be called
    * once (it will error the second time). The caller is responsible for closing the file

--- a/index.js
+++ b/index.js
@@ -326,6 +326,7 @@ const {
   Operation,
   MAX_U16_VALUE,
   MIN_U16_VALUE,
+  getSyntheticEofSequence,
   ptyResize,
   setCloseOnExec,
   getCloseOnExec,
@@ -335,6 +336,7 @@ module.exports.Pty = Pty;
 module.exports.Operation = Operation;
 module.exports.MAX_U16_VALUE = MAX_U16_VALUE;
 module.exports.MIN_U16_VALUE = MIN_U16_VALUE;
+module.exports.getSyntheticEofSequence = getSyntheticEofSequence;
 module.exports.ptyResize = ptyResize;
 module.exports.setCloseOnExec = setCloseOnExec;
 module.exports.getCloseOnExec = getCloseOnExec;

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.5.3",
+      "version": "3.6.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:wrapper": "tsup",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "vitest run",
-    "test:ci": "vitest --reporter=verbose --reporter=github-actions run",
+    "test:ci": "vitest --reporter=verbose --reporter=github-actions --allowOnly run",
     "test:hang": "vitest run --reporter=hanging-process",
     "universal": "napi universal",
     "version": "napi version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.5.3",
+  "version": "3.6.0",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use napi::Status::GenericFailure;
 use napi::{self, Env};
 use nix::errno::Errno;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
-use nix::libc::{self, c_int, ioctl, FIONREAD, TIOCSCTTY, TIOCSWINSZ};
+use nix::libc::{self, c_int, TIOCSCTTY, TIOCSWINSZ};
 use nix::pty::{openpty, Winsize};
 use nix::sys::termios::{self, SetArg};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,8 +302,9 @@ impl Pty {
 
       // by this point, child has closed its copy of the user_fd
       // lets inject our synthetic EOF OSC into the user_fd
+      // its ok to ignore the result here as we have a timeout on the nodejs side to handle if this write fails
       let mut file = unsafe { std::fs::File::from_raw_fd(raw_user_fd) };
-      let _ = file.write_all(&SYNTHETIC_EOF); // ignore, we have a timeout on the nodejs side to handle if this write fails
+      let _ = file.write_all(SYNTHETIC_EOF); // ignore, we have a timeout on the nodejs side to handle if this write fails
       mem::forget(file); // forget the file to avoid dropping it
 
       match wait_result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ impl Pty {
   /// descriptor.
   #[napi]
   #[allow(dead_code)]
-  pub fn take_fd(&mut self) -> Result<c_int, napi::Error> {
+  pub fn take_controller_fd(&mut self) -> Result<c_int, napi::Error> {
     if let Some(fd) = self.controller_fd.take() {
       Ok(fd.into_raw_fd())
     } else {
@@ -353,9 +353,11 @@ impl Pty {
     }
   }
 
+  /// Closes the owned file descriptor for the PTY controller. The Nodejs side must call this
+  /// when it is done with the file descriptor to avoid leaking FDs.
   #[napi]
   #[allow(dead_code)]
-  pub fn close_user_fd(&mut self) -> Result<(), napi::Error> {
+  pub fn drop_user_fd(&mut self) -> Result<(), napi::Error> {
     self.user_fd.take();
     Ok(())
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fs::{write, File};
 use std::io::ErrorKind;
 use std::io::{Error, Write};
 use std::mem;

--- a/syntheticEof.ts
+++ b/syntheticEof.ts
@@ -1,0 +1,83 @@
+import { Transform } from 'node:stream';
+
+// keep in sync with lib.rs::SYNTHETIC_EOF
+export const SYNTHETIC_EOF = Buffer.from('\x1B]7878\x1B\\');
+
+function getCommonPrefixLength(buffer: Buffer) {
+  for (let prefixLen = SYNTHETIC_EOF.length; prefixLen >= 1; prefixLen--) {
+    const suffix = buffer.subarray(buffer.length - prefixLen);
+    const prefix = SYNTHETIC_EOF.subarray(0, prefixLen);
+
+    if (suffix.equals(prefix)) {
+      return prefixLen;
+    }
+  }
+  return 0;
+}
+
+export class SyntheticEOFDetector extends Transform {
+  buffer: Buffer;
+  maxBufferSize: number;
+
+  constructor(options = {}) {
+    super(options);
+    this.buffer = Buffer.alloc(0);
+    this.maxBufferSize = SYNTHETIC_EOF.length - 1;
+  }
+
+  _transform(chunk: Buffer, encoding: string, callback: () => void) {
+    // combine any leftover buffer with new chunk
+    // and look for synthetic EOF in the combined data
+    const searchData = Buffer.concat([this.buffer, chunk]);
+    const eofIndex = searchData.indexOf(SYNTHETIC_EOF);
+
+    // found EOF - emit data before it
+    if (eofIndex !== -1) {
+      const beforeEOF = searchData.subarray(0, eofIndex);
+      const afterEOF = searchData.subarray(eofIndex + SYNTHETIC_EOF.length);
+
+      if (beforeEOF.length > 0) {
+        this.push(Buffer.from(beforeEOF));
+      }
+
+      this.emit('synthetic-eof');
+
+      // Continue processing remaining data (might have more EOFs)
+      if (afterEOF.length > 0) {
+        this._transform(Buffer.from(afterEOF), encoding, callback);
+        return;
+      }
+
+      this.buffer = Buffer.alloc(0);
+    } else {
+      // no EOF found - emit all the data except for the enough of a buffer
+      // to potentially match the start of an EOF sequence next time
+      const commonPrefixLen = getCommonPrefixLength(searchData);
+      if (commonPrefixLen > 0) {
+        // has common prefix - buffer the suffix, emit the rest
+        const emitSize = searchData.length - commonPrefixLen;
+
+        if (emitSize > 0) {
+          const toEmit = searchData.subarray(0, emitSize);
+          this.push(Buffer.from(toEmit));
+        }
+
+        this.buffer = Buffer.from(searchData.subarray(emitSize));
+      } else {
+        // no common prefix - emit everything, clear buffer
+        this.push(Buffer.from(searchData));
+        this.buffer = Buffer.alloc(0);
+      }
+    }
+
+    callback();
+  }
+
+  _flush(callback: () => void) {
+    if (this.buffer.length > 0) {
+      this.push(this.buffer);
+    }
+
+    callback();
+  }
+}

--- a/syntheticEof.ts
+++ b/syntheticEof.ts
@@ -1,71 +1,73 @@
 import { Transform } from 'node:stream';
+import { getSyntheticEofSequence } from './index.js';
 
 // keep in sync with lib.rs::SYNTHETIC_EOF
-export const SYNTHETIC_EOF = Buffer.from('\x1B]7878\x1B\\');
+export const SYNTHETIC_EOF = getSyntheticEofSequence();
+export const EOF_EVENT = 'synthetic-eof';
 
-function getCommonPrefixLength(buffer: Buffer) {
-  for (let prefixLen = SYNTHETIC_EOF.length; prefixLen >= 1; prefixLen--) {
-    const suffix = buffer.subarray(buffer.length - prefixLen);
-    const prefix = SYNTHETIC_EOF.subarray(0, prefixLen);
+// get the longest suffix of buffer that is a prefix of SYNTHETIC_EOF
+function getBufferEndPrefixLength(buffer: Buffer) {
+  const maxLen = Math.min(buffer.length, SYNTHETIC_EOF.length);
+  for (let len = maxLen; len > 0; len--) {
+    let match = true;
+    for (let i = 0; i < len; i++) {
+      if (buffer[buffer.length - len + i] !== SYNTHETIC_EOF[i]) {
+        match = false;
+        break;
+      }
+    }
 
-    if (suffix.equals(prefix)) {
-      return prefixLen;
+    if (match) {
+      return len;
     }
   }
+
   return 0;
 }
 
 export class SyntheticEOFDetector extends Transform {
   buffer: Buffer;
-  maxBufferSize: number;
 
   constructor(options = {}) {
     super(options);
     this.buffer = Buffer.alloc(0);
-    this.maxBufferSize = SYNTHETIC_EOF.length - 1;
   }
 
-  _transform(chunk: Buffer, encoding: string, callback: () => void) {
-    // combine any leftover buffer with new chunk
-    // and look for synthetic EOF in the combined data
+  _transform(chunk: Buffer, _encoding: string, callback: () => void) {
     const searchData = Buffer.concat([this.buffer, chunk]);
     const eofIndex = searchData.indexOf(SYNTHETIC_EOF);
 
-    // found EOF - emit data before it
     if (eofIndex !== -1) {
-      const beforeEOF = searchData.subarray(0, eofIndex);
-      const afterEOF = searchData.subarray(eofIndex + SYNTHETIC_EOF.length);
-
-      if (beforeEOF.length > 0) {
-        this.push(Buffer.from(beforeEOF));
+      // found EOF - emit everything before it
+      if (eofIndex > 0) {
+        this.push(searchData.subarray(0, eofIndex));
       }
 
-      this.emit('synthetic-eof');
+      this.emit(EOF_EVENT);
 
-      // Continue processing remaining data (might have more EOFs)
+      // emit everything after EOF (if any) and clear buffer
+      const afterEOF = searchData.subarray(eofIndex + SYNTHETIC_EOF.length);
       if (afterEOF.length > 0) {
-        this._transform(Buffer.from(afterEOF), encoding, callback);
-        return;
+        this.push(afterEOF);
       }
 
       this.buffer = Buffer.alloc(0);
     } else {
-      // no EOF found - emit all the data except for the enough of a buffer
-      // to potentially match the start of an EOF sequence next time
-      const commonPrefixLen = getCommonPrefixLength(searchData);
+      // no EOF - buffer potential partial match at end
+
+      // get the longest suffix of buffer that is a prefix of SYNTHETIC_EOF
+      // and emit everything before it
+      // this is done for the case which the eof happened to be split across multiple chunks
+      const commonPrefixLen = getBufferEndPrefixLength(searchData);
+
       if (commonPrefixLen > 0) {
-        // has common prefix - buffer the suffix, emit the rest
         const emitSize = searchData.length - commonPrefixLen;
-
         if (emitSize > 0) {
-          const toEmit = searchData.subarray(0, emitSize);
-          this.push(Buffer.from(toEmit));
+          this.push(searchData.subarray(0, emitSize));
         }
-
-        this.buffer = Buffer.from(searchData.subarray(emitSize));
+        this.buffer = searchData.subarray(emitSize);
       } else {
-        // no common prefix - emit everything, clear buffer
-        this.push(Buffer.from(searchData));
+        this.push(searchData);
         this.buffer = Buffer.alloc(0);
       }
     }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -77,9 +77,9 @@ describe('PTY', { repeats: 500 }, () => {
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
     expect(buffer.trim()).toBe(message);
-    expect(getOpenFds()).toStrictEqual(oldFds);
     expect(pty.write.writable).toBe(false);
     expect(pty.read.readable).toBe(false);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('captures an exit code', async () => {
@@ -132,7 +132,7 @@ describe('PTY', { repeats: 500 }, () => {
 
     const expectedResult = 'hello cat\r\nhello cat\r\n';
     expect(result.trim()).toStrictEqual(expectedResult.trim());
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('can be started in non-interactive fashion', async () => {
@@ -157,7 +157,7 @@ describe('PTY', { repeats: 500 }, () => {
     let result = buffer.toString();
     const expectedResult = '\r\n';
     expect(result.trim()).toStrictEqual(expectedResult.trim());
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('can be resized', async () => {
@@ -211,7 +211,7 @@ describe('PTY', { repeats: 500 }, () => {
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
     expect(state).toBe('done');
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('respects working directory', async () => {
@@ -234,7 +234,7 @@ describe('PTY', { repeats: 500 }, () => {
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
     expect(buffer.trim()).toBe(cwd);
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('respects env', async () => {
@@ -260,7 +260,7 @@ describe('PTY', { repeats: 500 }, () => {
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
     expect(buffer.trim()).toBe(message);
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test("resize after exit shouldn't throw", async () => {
@@ -330,7 +330,7 @@ describe('PTY', { repeats: 500 }, () => {
       ).toBe(i);
     }
 
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('doesnt miss large output from fast commands', async () => {
@@ -417,7 +417,7 @@ describe('PTY', { repeats: 500 }, () => {
     }
 
     await Promise.all(promises);
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('can run concurrent shells', async () => {
@@ -474,7 +474,7 @@ describe('PTY', { repeats: 500 }, () => {
       expect(result).toStrictEqual(expectedResult);
     }
 
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test("doesn't break when executing non-existing binary", async () => {
@@ -487,7 +487,7 @@ describe('PTY', { repeats: 500 }, () => {
       });
     }).rejects.toThrow('No such file or directory');
 
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('cannot be written to after closing', async () => {
@@ -515,7 +515,7 @@ describe('PTY', { repeats: 500 }, () => {
       }
     });
     await vi.waitFor(() => receivedError);
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   test('cannot resize when out of range', async () => {
@@ -554,7 +554,7 @@ describe('PTY', { repeats: 500 }, () => {
 
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, -1);
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 });
 
@@ -745,7 +745,7 @@ describe('cgroup opts', async () => {
     // Verify that the process was placed in the correct cgroup by
     // checking its output contains our unique slice name
     expect(buffer).toContain(cgroupState.sliceName);
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   testOnlyOnDarwin('cgroup is not supported on darwin', async () => {
@@ -822,7 +822,7 @@ describe('sandbox opts', { repeats: 10 }, async () => {
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
     expect(buffer).toContain('hello');
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   testSkipOnDarwin('basic protection against git-yeetage', async () => {
@@ -867,7 +867,7 @@ describe('sandbox opts', { repeats: 10 }, async () => {
     expect(buffer.trimEnd()).toBe(
       `Tried to delete a forbidden path: ${gitPath}`,
     );
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
   testSkipOnDarwin('can exclude prefixes', async () => {
@@ -913,7 +913,7 @@ describe('sandbox opts', { repeats: 10 }, async () => {
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
     expect(buffer.trimEnd()).toBe('');
-    expect(getOpenFds()).toStrictEqual(oldFds);
+    await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -371,15 +371,10 @@ describe('PTY', { repeats: 500 }, () => {
     });
 
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
-    try {
-      expect(onExit).toHaveBeenCalledWith(null, 0);
-      expect(buffer.toString().trim().replace(/\r/g, '').length).toBe(
-        payload.length,
-      );
-    } catch (e) {
-      console.log('FAIL');
-      throw e;
-    }
+    expect(onExit).toHaveBeenCalledWith(null, 0);
+    expect(buffer.toString().trim().replace(/\r/g, '').length).toBe(
+      payload.length,
+    );
   });
 
   testSkipOnDarwin('does not leak files', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -371,8 +371,15 @@ describe('PTY', { repeats: 500 }, () => {
     });
 
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
-    expect(onExit).toHaveBeenCalledWith(null, 0);
-    expect(buffer.toString().trim().replace(/\r/g, '').length).toBe(payload.length);
+    try {
+      expect(onExit).toHaveBeenCalledWith(null, 0);
+      expect(buffer.toString().trim().replace(/\r/g, '').length).toBe(
+        payload.length,
+      );
+    } catch (e) {
+      console.log('FAIL');
+      throw e;
+    }
   });
 
   testSkipOnDarwin('does not leak files', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,7 +57,7 @@ function getOpenFds(): FdRecord {
 }
 
 describe('PTY', { repeats: 0 }, () => {
-  test('spawns and exits', async () => {
+  test.only('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';
     let buffer = '';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -56,7 +56,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 0 }, () => {
+describe('PTY', { repeats: 500 }, () => {
   test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -56,8 +56,8 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 500 }, () => {
-  test('spawns and exits', async () => {
+describe('PTY', { repeats: 0 }, () => {
+  test.only('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';
     let buffer = '';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,7 +57,7 @@ function getOpenFds(): FdRecord {
 }
 
 describe('PTY', { repeats: 500 }, () => {
-  test.only('spawns and exits', async () => {
+  test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';
     let buffer = '';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -354,7 +354,7 @@ describe('PTY', { repeats: 500 }, () => {
     expect(buffer.toString().length).toBe(payload.length);
   });
 
-  test.only('doesnt miss lots of lines from bash', async () => {
+  test('doesnt miss lots of lines from bash', async () => {
     const payload = Array.from({ length: 5000 }, (_, i) => i).join('\n');
     let buffer = Buffer.from('');
     const onExit = vi.fn();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -56,7 +56,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 0 }, () => {
+describe('PTY', { repeats: 500 }, () => {
   test.only('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -56,7 +56,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 500 }, () => {
+describe('PTY', { repeats: 0 }, () => {
   test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';
@@ -355,7 +355,7 @@ describe('PTY', { repeats: 500 }, () => {
   });
 
   test.only('doesnt miss lots of lines from bash', async () => {
-    const payload = Array.from({ length: 4096 * 5 }, (_, i) => i).join('\n');
+    const payload = Array.from({ length: 5000 }, (_, i) => i).join('\n');
     let buffer = Buffer.from('');
     const onExit = vi.fn();
 
@@ -372,7 +372,7 @@ describe('PTY', { repeats: 500 }, () => {
 
     await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
     expect(onExit).toHaveBeenCalledWith(null, 0);
-    expect(buffer.toString().trim().replace(/\r/g, '')).toBe(payload.trim());
+    expect(buffer.toString().trim().replace(/\r/g, '').length).toBe(payload.length);
   });
 
   testSkipOnDarwin('does not leak files', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -354,6 +354,27 @@ describe('PTY', { repeats: 500 }, () => {
     expect(buffer.toString().length).toBe(payload.length);
   });
 
+  test.only('doesnt miss lots of lines from bash', async () => {
+    const payload = Array.from({ length: 4096 * 5 }, (_, i) => i).join('\n');
+    let buffer = Buffer.from('');
+    const onExit = vi.fn();
+
+    const pty = new Pty({
+      command: 'bash',
+      args: ['-c', `echo -n "${payload}"`],
+      onExit,
+    });
+
+    const readStream = pty.read;
+    readStream.on('data', (data) => {
+      buffer = Buffer.concat([buffer, data]);
+    });
+
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
+    expect(onExit).toHaveBeenCalledWith(null, 0);
+    expect(buffer.toString().trim().replace(/\r/g, '')).toBe(payload.trim());
+  });
+
   testSkipOnDarwin('does not leak files', async () => {
     const oldFds = getOpenFds();
     const promises = [];

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -56,7 +56,7 @@ function getOpenFds(): FdRecord {
   return fds;
 }
 
-describe('PTY', { repeats: 500 }, () => {
+describe('PTY', { repeats: 0 }, () => {
   test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -57,7 +57,7 @@ function getOpenFds(): FdRecord {
 }
 
 describe('PTY', { repeats: 0 }, () => {
-  test.only('spawns and exits', async () => {
+  test('spawns and exits', async () => {
     const oldFds = getOpenFds();
     const message = 'hello from a pty';
     let buffer = '';

--- a/tests/syntheticEOF.test.ts
+++ b/tests/syntheticEOF.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SyntheticEOFDetector, SYNTHETIC_EOF } from '../syntheticEof';
+
+describe('sequence', () => {
+  it('should have correct EOF sequence', () => {
+    expect(SYNTHETIC_EOF).toEqual(
+      Buffer.from([0x1b, 0x5d, 0x37, 0x38, 0x37, 0x38, 0x1b, 0x5c]),
+    );
+    expect(SYNTHETIC_EOF.length).toBe(8);
+  });
+});
+
+describe('SyntheticEOFDetector', () => {
+  let detector: SyntheticEOFDetector;
+  let onData: (data: Buffer) => void;
+  let onEOF: () => void;
+  let output: Buffer;
+
+  beforeEach(() => {
+    detector = new SyntheticEOFDetector();
+    output = Buffer.alloc(0);
+    onData = vi.fn((data: Buffer) => (output = Buffer.concat([output, data])));
+    onEOF = vi.fn();
+
+    detector.on('data', onData);
+    detector.on('synthetic-eof', onEOF);
+  });
+
+  it('should handle EOF at the end of stream', async () => {
+    detector.write('Before EOF');
+    detector.write(SYNTHETIC_EOF);
+    detector.end();
+
+    expect(output.toString()).toBe('Before EOF');
+    expect(onEOF).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle EOF split across chunks', async () => {
+    detector.write('Data1');
+    detector.write('\x1B]78'); // Partial EOF
+    detector.write('78\x1B\\'); // Complete EOF
+    detector.write('Data2');
+    detector.end();
+
+    expect(output.toString()).toBe('Data1Data2');
+    expect(onEOF).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass through data when no EOF is present', async () => {
+    detector.write('Just normal data');
+    detector.write(' with no EOF');
+    detector.end();
+
+    expect(output.toString()).toBe('Just normal data with no EOF');
+    expect(onEOF).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger on partial EOF at end', async () => {
+    detector.write('Data');
+    detector.write('\x1B]78'); // Incomplete EOF
+    detector.end();
+
+    expect(output.toString()).toBe('Data\x1B]78');
+    expect(onEOF).not.toHaveBeenCalled();
+  });
+
+  it('should handle EOF split in multiple ways', async () => {
+    // Split after escape
+    detector.write('\x1B');
+    detector.write(']7878\x1B\\');
+    detector.write('data1');
+
+    // Split in middle
+    detector.write('\x1B]78');
+    detector.write('78\x1B\\');
+    detector.write('data2');
+    detector.end();
+
+    expect(output.toString()).toBe('data1data2');
+    expect(onEOF).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not hold up data that isnt a prefix of EOF', async () => {
+    detector.write('Data that is definitely not an EOF prefix');
+
+    expect(output.toString()).toBe('Data that is definitely not an EOF prefix');
+    expect(onEOF).not.toHaveBeenCalled();
+
+    detector.end();
+    expect(onEOF).not.toHaveBeenCalled();
+  });
+
+  it('should emit events in correct order', async () => {
+    const detector = new SyntheticEOFDetector();
+    const events: Array<
+      | {
+          type: 'eof';
+        }
+      | {
+          type: 'data';
+          data: string;
+        }
+    > = [];
+
+    detector.on('data', (chunk) => {
+      events.push({ type: 'data', data: chunk.toString() });
+    });
+    detector.on('synthetic-eof', () => {
+      events.push({ type: 'eof' });
+    });
+
+    const finished = new Promise((resolve) => {
+      detector.on('end', resolve);
+    });
+
+    detector.write('before');
+    detector.write(SYNTHETIC_EOF);
+    detector.write('after');
+    detector.end();
+
+    await finished;
+
+    expect(events).toEqual([
+      { type: 'data', data: 'before' },
+      { type: 'eof' },
+      { type: 'data', data: 'after' },
+    ]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 export default {
   test: {
     exclude: ['node_modules', 'dist', '.direnv'],
+    fileParallelism: false
   },
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ export default {
   test: {
     exclude: ['node_modules', 'dist', '.direnv'],
     fileParallelism: false,
-    pool: 'threads',
+    pool: 'forks',
   },
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,7 @@
 export default {
   test: {
     exclude: ['node_modules', 'dist', '.direnv'],
-    fileParallelism: false
+    fileParallelism: false,
+    pool: 'threads',
   },
 };

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -81,9 +81,10 @@ export class Pty {
       console.log('mockedExit', { error, code });
       markExited({ error, code });
 
-      setImmediate(() => {
+      // set immediate to give us one more chance to read any remaining data
+      setTimeout(() => {
         this.#pty.closeUserFd();
-      });
+      }, 100);
     };
 
     // when pty exits, we should wait until the fd actually ends (end OR error)

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -82,6 +82,7 @@ export class Pty {
       markExited({ error, code });
 
       // try to read the last of the data before closing the fd
+      console.log('pausing')
       this.read.pause();
       let chunk: Buffer | null;
       while ((chunk = this.read.read()) !== null) {
@@ -90,6 +91,7 @@ export class Pty {
       }
 
       setImmediate(() => {
+        console.log('closing user fd')
         this.#pty.closeUserFd();
       });
     };

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -151,12 +151,6 @@ export class Pty {
       // we dont yank the user fd away from them until the program actually exits
       // (and drops its copy of the user fd)
       await exitResult;
-
-      if (this.#userFdDropped) {
-        return;
-      }
-
-      this.#userFdDropped = true;
       this.dropUserFd();
     });
   }

--- a/wrapper.ts
+++ b/wrapper.ts
@@ -85,6 +85,7 @@ export class Pty {
       this.read.pause();
       let chunk: Buffer | null;
       while ((chunk = this.read.read()) !== null) {
+        console.log('boi has data')
         this.read.emit('data', chunk);
       }
 
@@ -153,10 +154,7 @@ export class Pty {
       throw err;
     };
 
-    this.read.on('error', (err) => {
-      console.error('error:', err);
-      handleError(err);
-    });
+    this.read.on('error', handleError);
   }
 
   close() {


### PR DESCRIPTION
turns out https://github.com/replit/ruspty/pull/51 reduced the race rate but did not eliminate it completely. we still see the data race bug very rarely and it is exacerbated on high-numbers of repeats in the tests and/or high nodejs event loop utilization

my old theory was:
- the user fd is O_NONBLOCK clear so any writes there should block until its made its way into the 4kb intermediary buffer
- as a result, when the .wait returns, we know that the program output has at least made it fully into the the user fd input buffer
- because we poll until `controller_inq == 0 && controller_outq == 0 && user_inq == 0 && user_outq == 0`, in theory we should never call the js side exit code until theres truly nothing left in the pipe (i.e. the readstream on the nodejs side has it in its own buffer)

HOWEVER, with some logging i saw a few cases where in fact `controller_inq == 0 && controller_outq == 0 && user_inq == 0 && user_outq == 0`, the program had exited, yet the nodejs side still missed some data

what i think is _actually_ happening is that
1. one of libuv's io threads reads the data from the controller side and queues a data event on the stream
2. polling exits as now theres no more data in the queues we immediately `drop(user_fd);` which [sets TTY_OTHER_CLOSED synchronously](https://github.com/torvalds/linux/blob/4ff71af020ae59ae2d83b174646fc2ad9fcd4dc4/drivers/tty/pty.c#L66) and we get an error event queued on the stream
3. if the nodejs event loop happens to read error before data, we emit 'end' and mark the data as read even though technically nodejs hasnt processed the data event yet so we drop data :(

how we fix it:
1. axe poll_pty_fds_until_read
2. make Pty struct own user_fd and expose a method for the js side to drop this fd when its done
3. when child.wait finishes, write a synthetic 'EOF' that is actually a custom OSC terminal control sequence (`\x1B]7878\x1B\\`, 7878 is RUST on the phonepad :)) to the user fd (a cursory search shows no results, it seems _very_ unlikely for this sequence to appear randomly)
4. on the nodejs wrapper side, create a transform stream that parses out the synthetic EOF and emits it as a custom event when it happens
5. when the nodejs side hits this EOF, we know we are actually at the end of the data stream and can safely drop user_fd

node-pty had the [same problem](https://github.com/microsoft/node-pty/issues/72) and did the :grug: brain thing and [added a wait 250ms](https://github.com/microsoft/vscode/commit/9464b54f39d8db943ddd4c134d9bef835b7bd506
) so im calling it slightly more ok