### PR TITLE
Adopt npm trusted publishing in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,8 +5,7 @@ env:
   MACOSX_DEPLOYMENT_TARGET: '10.13'
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 'on':
   push:
     branches:
@@ -138,12 +137,16 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs:
       - test
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         run: npm ci
       - name: Download all artifacts
@@ -158,10 +161,4 @@ jobs:
         run: ls -R ./npm
         shell: bash
       - name: Publish
-        run: |
-          npm config set provenance true
-          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-          npm publish --access public
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Following ["Publish It" section from `napi-rs` docs](https://napi.rs/docs/introd
 2. `npm version [major|minor|patch]`
 3. Send that as a Pull Request to GitHub. Ensure that the commit message consisting **only** of `x.y.z` - this is how the CI decides to publish to `npm`!
 
-`NPM_TOKEN` is part of the repo secrets, generated [like this](https://httptoolkit.com/blog/automatic-npm-publish-gha/).
+Configure npm trusted publishing for `replit/ruspty` with the workflow filename `CI.yml` before merging a version bump PR. The publish job now uses GitHub OIDC, so `NPM_TOKEN` is no longer required.


### PR DESCRIPTION
## Why
- npm trusted publishing via GitHub OIDC removes the long-lived `NPM_TOKEN` requirement from the release workflow.
- npm's trusted publisher flow also requires a newer Node/npm runtime in the publish job.

## What changed
- reduced the workflow's default permissions to read-only and scoped `id-token: write` to the `publish` job
- switched the publish job to `actions/setup-node` with Node 24 and the npm registry URL configured
- removed token-based npm auth from `npm publish` and updated the publishing docs to point at the `CI.yml` trusted publisher setup

## Test plan
- `git diff --check`
- did not run repo tests; this only changes GitHub Actions workflow and publishing docs

## Revertibility
- Safe to revert in git.
- If `NPM_TOKEN` is removed during rollout, reverting this workflow also requires restoring that secret or updating npm publishing settings to match.

~ written by Zerg 👾