### PR TITLE
Add no-new-privileges PTY option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,7 @@ export interface PtyOptions {
   size?: Size;
   cgroupPath?: string;
   newCgroupNamespace?: boolean;
+  noNewPrivileges?: boolean;
   apparmorProfile?: string;
   interactive?: boolean;
   sandbox?: SandboxOptions;

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-arm64",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-darwin-x64",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "os": [
     "darwin"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty-linux-x64-gnu",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "os": [
     "linux"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@replit/ruspty",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ruspty",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "main": "dist/wrapper.js",
   "types": "dist/wrapper.d.ts",
   "author": "Szymon Kaliski <hi@szymonkaliski.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ struct PtyOptions {
   pub size: Option<Size>,
   pub cgroup_path: Option<String>,
   pub new_cgroup_namespace: Option<bool>,
+  pub no_new_privileges: Option<bool>,
   pub apparmor_profile: Option<String>,
   pub interactive: Option<bool>,
   pub sandbox: Option<SandboxOptions>,
@@ -133,6 +134,14 @@ impl Pty {
       return Err(napi::Error::new(
         napi::Status::GenericFailure,
         "new_cgroup_namespace is only supported on Linux",
+      ));
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    if opts.no_new_privileges.unwrap_or(false) {
+      return Err(napi::Error::new(
+        napi::Status::GenericFailure,
+        "no_new_privileges is only supported on Linux",
       ));
     }
 
@@ -296,6 +305,13 @@ impl Pty {
         libc::signal(libc::SIGQUIT, libc::SIG_DFL);
         libc::signal(libc::SIGTERM, libc::SIG_DFL);
         libc::signal(libc::SIGALRM, libc::SIG_DFL);
+
+        #[cfg(target_os = "linux")]
+        if opts.no_new_privileges.unwrap_or(false)
+          && libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0
+        {
+          return Err(Error::last_os_error());
+        }
 
         Ok(())
       });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -160,6 +160,25 @@ describe('PTY', { repeats: 500 }, () => {
     await vi.waitFor(() => expect(getOpenFds()).toStrictEqual(oldFds));
   });
 
+  testSkipOnDarwin('sets no new privileges before exec', async () => {
+    let buffer = '';
+    const onExit = vi.fn();
+    const pty = new Pty({
+      command: 'sh',
+      args: ['-c', "awk '/^NoNewPrivs:/ { print $2 }' /proc/self/status"],
+      noNewPrivileges: true,
+      onExit,
+    });
+
+    pty.read.on('data', (data) => {
+      buffer += data.toString();
+    });
+
+    await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1));
+    expect(onExit).toHaveBeenCalledWith(null, 0);
+    expect(buffer.trim()).toBe('1');
+  });
+
   test('can be resized', async () => {
     const oldFds = getOpenFds();
     let buffer = '';


### PR DESCRIPTION
## What changed

Adds an opt-in `noNewPrivileges` option for Linux PTY children. The child sets the kernel flag after PTY, cgroup, sandbox, and AppArmor setup, immediately before it executes the requested command. This release publishes version `3.8.0` for the PID2 consumer.

## Why

PID2 needs a kernel-owned marker for user-code processes. VMGuard will use this marker to deny untrusted telemetry connections.

References PLAT-1975

## Rollout and rollback

The option defaults to false. PID2 can adopt it after the package release. Revert this PR to remove the option and its release.

~ written by Zerg :space_invader: ([fortified-queen-e5a0](https://zerg.zergrush.dev/chat?id=fortified-queen-e5a0))